### PR TITLE
fix(mcp): MCP-valid ResourceMetadata wire shape + empty templates/list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ uuid = { version = "1.10", features = ["v4"] }
 # 0.10+ is the current binary-storage MentisDB line. 0.4 was the last
 # pre-modern series cloudllm targeted; Jsonl is legacy-only upstream.
 mentisdb = "0.10"
-mcp = { package = "cloudllm_mcp", path = "mcp", version = "0.3.5", features = ["server"] }
+mcp = { package = "cloudllm_mcp", path = "mcp", version = "0.3.6", features = ["server"] }
 
 [dev-dependencies]
 tempfile = "3.23"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,13 @@
+0.15.11 (unreleased) — cloudllm_mcp 0.3.6
+  - fix(mcp): emit MCP-valid ResourceMetadata on resources/list
+    - [ADDED] required `name` on `ResourceMetadata` (derived from URI path
+      segment; override with `with_name`)
+    - serde wire keys: `mimeType` (was `mime_type`), `_meta` (was `metadata`);
+      deserialize still accepts legacy snake_case aliases
+    - [ADDED] `resources/templates/list` → HTTP 200 `{ "resourceTemplates": [] }`
+      so FastMCP template probes do not get method-not-found / 400
+    - unit + streamable_http tests cover wire shape and empty templates list
+
 0.15.10 JUL/10/2026
   - feat(openai): add GPT-5.6 Sol / Terra / Luna model enums
     - [ADDED] `Model::GPT56Sol` → `"gpt-5.6-sol"` (frontier flagship)

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudllm_mcp"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Angel Leon <gubatron@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/mcp/src/resources.rs
+++ b/mcp/src/resources.rs
@@ -45,29 +45,60 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
 
-/// Metadata describing a resource
+/// Metadata describing a resource.
+///
+/// Wire JSON follows the MCP resource schema: required `name`, camelCase
+/// `mimeType`, and `_meta` for free-form metadata. Rust field names stay
+/// idiomatic (`mime_type`, `metadata`); serde renames handle the wire form.
+/// Deserialize also accepts the legacy snake_case keys (`mime_type`,
+/// `metadata`) so older payloads still round-trip during upgrades.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourceMetadata {
+    /// Programmatic resource name (MCP `BaseMetadata.name`, required).
+    ///
+    /// Examples: `"core"`, `"config.yaml"`. Defaults to the final URI path
+    /// segment when constructed via [`ResourceMetadata::new`].
+    pub name: String,
     /// Unique resource identifier (URI)
     /// Examples: "file:///config.yaml", "schema:///users", "db:///schema.sql"
     pub uri: String,
     /// Human-readable description of the resource
     pub description: String,
-    /// Optional MIME type of the resource content
+    /// Optional MIME type of the resource content (wire: `mimeType`)
+    #[serde(
+        default,
+        rename = "mimeType",
+        alias = "mime_type",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub mime_type: Option<String>,
-    /// Additional metadata
+    /// Additional metadata (wire: `_meta`)
+    #[serde(default, rename = "_meta", alias = "metadata")]
     pub metadata: HashMap<String, serde_json::Value>,
 }
 
 impl ResourceMetadata {
-    /// Create a new resource with URI and description
+    /// Create a new resource with URI and description.
+    ///
+    /// `name` is derived from the final path segment of `uri` (e.g.
+    /// `mentisdb://skill/core` → `"core"`). Use [`Self::with_name`] to set an
+    /// explicit MCP name when the URI segment is not the desired name.
     pub fn new(uri: impl Into<String>, description: impl Into<String>) -> Self {
+        let uri = uri.into();
+        let name = default_name_from_uri(&uri);
         Self {
-            uri: uri.into(),
+            name,
+            uri,
             description: description.into(),
             mime_type: None,
             metadata: HashMap::new(),
         }
+    }
+
+    /// Override the MCP `name` field (required on the wire).
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
     }
 
     /// Set the MIME type for this resource
@@ -81,6 +112,17 @@ impl ResourceMetadata {
         self.metadata.insert(key.into(), value);
         self
     }
+}
+
+/// Derive a default MCP resource name from a URI's final path segment.
+fn default_name_from_uri(uri: &str) -> String {
+    let trimmed = uri.trim_end_matches('/');
+    trimmed
+        .rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("resource")
+        .to_string()
 }
 
 /// Trait for implementing resource protocols
@@ -136,3 +178,78 @@ impl std::fmt::Display for ResourceError {
 }
 
 impl std::error::Error for ResourceError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    #[test]
+    fn new_derives_name_from_uri_path_segment() {
+        let resource = ResourceMetadata::new(
+            "mentisdb://skill/core",
+            "MentisDB operating skill",
+        )
+        .with_mime_type("text/markdown")
+        .with_metadata("recommended_first", json!(true));
+
+        assert_eq!(resource.name, "core");
+        assert_eq!(resource.uri, "mentisdb://skill/core");
+        assert_eq!(resource.mime_type.as_deref(), Some("text/markdown"));
+    }
+
+    #[test]
+    fn with_name_overrides_derived_name() {
+        let resource = ResourceMetadata::new("file:///config.yaml", "config").with_name("app-config");
+        assert_eq!(resource.name, "app-config");
+    }
+
+    #[test]
+    fn serialize_uses_mcp_wire_keys() {
+        let resource = ResourceMetadata::new("mentisdb://skill/core", "skill")
+            .with_name("core")
+            .with_mime_type("text/markdown")
+            .with_metadata("recommended_first", json!(true));
+
+        let value = serde_json::to_value(&resource).expect("serialize");
+        assert_eq!(value["name"], "core");
+        assert_eq!(value["uri"], "mentisdb://skill/core");
+        assert_eq!(value["mimeType"], "text/markdown");
+        assert_eq!(value["_meta"]["recommended_first"], true);
+        assert!(value.get("mime_type").is_none());
+        assert!(value.get("metadata").is_none());
+    }
+
+    #[test]
+    fn deserialize_accepts_legacy_snake_case_keys() {
+        let legacy = json!({
+            "name": "core",
+            "uri": "mentisdb://skill/core",
+            "description": "skill",
+            "mime_type": "text/markdown",
+            "metadata": {"priority": 1}
+        });
+        let resource: ResourceMetadata =
+            serde_json::from_value(legacy).expect("deserialize legacy");
+        assert_eq!(resource.name, "core");
+        assert_eq!(resource.mime_type.as_deref(), Some("text/markdown"));
+        assert_eq!(resource.metadata.get("priority"), Some(&json!(1)));
+    }
+
+    #[test]
+    fn deserialize_accepts_mcp_wire_keys() {
+        let wire = json!({
+            "name": "core",
+            "uri": "mentisdb://skill/core",
+            "description": "skill",
+            "mimeType": "text/markdown",
+            "_meta": {"recommended_first": true}
+        });
+        let resource: ResourceMetadata = serde_json::from_value(wire).expect("deserialize wire");
+        assert_eq!(resource.mime_type.as_deref(), Some("text/markdown"));
+        assert_eq!(
+            resource.metadata.get("recommended_first"),
+            Some(&Value::Bool(true))
+        );
+    }
+}

--- a/mcp/src/streamable_http.rs
+++ b/mcp/src/streamable_http.rs
@@ -688,6 +688,7 @@ fn broadcast_jsonrpc_result(
         "tools/call" => "tool_called",
         "resources/list" => "resources_listed",
         "resources/read" => "resource_read",
+        "resources/templates/list" => "resource_templates_listed",
         _ => method,
     };
     broadcaster.send(SseMessage::with_event(
@@ -847,6 +848,10 @@ async fn handle_jsonrpc_request(
                 ]
             }))
         }
+        // FastMCP / MCP clients probe templates after resources/list. MentisDB
+        // (and other resource servers without templates) must return an empty
+        // list with HTTP 200 rather than method-not-found / 400.
+        "resources/templates/list" => Ok(json!({ "resourceTemplates": [] })),
         _ => Err((
             StatusCode::BAD_REQUEST,
             -32601,

--- a/mcp/tests/streamable_http_tests.rs
+++ b/mcp/tests/streamable_http_tests.rs
@@ -452,3 +452,22 @@ async fn test_unknown_method_returns_bad_request() {
         .unwrap()
         .contains("Method not found"));
 }
+
+#[tokio::test]
+async fn test_resources_templates_list_returns_empty_ok() {
+    let router = make_router(false);
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "resources/templates/list",
+        "params": {}
+    });
+    let (status, text) = post_json(&router, body).await;
+    assert_eq!(status, StatusCode::OK);
+    let response: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert!(response.get("error").is_none());
+    assert_eq!(
+        response["result"]["resourceTemplates"],
+        json!([])
+    );
+}


### PR DESCRIPTION
## Summary

`cloudllm_mcp` `ResourceMetadata` serialized with snake_case `mime_type` / `metadata` and **no** required MCP `name`. FastMCP / AggregateProvider then reject `resources/list` (`ListResourcesResult` validation), so mounted clients (e.g. Context Engine → MentisDB) never see `mentisdb://skill/core`.

This PR:

- Adds required `name` on `ResourceMetadata` (derived from URI path segment; override via `with_name`)
- Serializes wire keys as MCP expects: `mimeType`, `_meta` (Rust fields stay `mime_type` / `metadata`)
- Deserializes both MCP wire keys and legacy snake_case aliases
- Handles `resources/templates/list` with HTTP 200 `{ "resourceTemplates": [] }` instead of method-not-found / 400
- Bumps `cloudllm_mcp` to **0.3.6**
- Adds unit + streamable HTTP tests

Companion MentisDB PR: https://github.com/CloudLLM-ai/mentisdb/pull/19

## Live evidence (MentisDB 0.10.4 / cloudllm_mcp 0.3.5)

```json
// resources/list — missing name, snake_case keys
{"uri":"mentisdb://skill/core","mime_type":"text/markdown","metadata":{"recommended_first":true},...}

// resources/templates/list
HTTP 400 {"error":{"code":-32601,"message":"Method not found: resources/templates/list"}}
```

## Test plan

- [x] `cargo test -p cloudllm_mcp --lib resources::tests`
- [x] `cargo test -p cloudllm_mcp --features server --test streamable_http_tests test_resources_templates_list_returns_empty_ok`
- [ ] Publish `cloudllm_mcp` 0.3.6 to crates.io after merge
- [ ] Merge companion MentisDB PR (#19)